### PR TITLE
Switch DS guide to tabs

### DIFF
--- a/_includes/tabs.html
+++ b/_includes/tabs.html
@@ -1,0 +1,9 @@
+{% assign tab-group = "tab" %}
+{% if include.index > 0 %}{% assign tab-group = tab-group | append: include.index %}{% endif %}
+<div class="tab-container" data-tab-group="{{ tab-group }}">
+	{% for tab in page.tabs[include.index] %}
+		<input id="{{ tab-group }}-{{ tab[0] }}" class="d-none" name="{{ tab-group }}" type="radio" {% if forloop.first %}checked{% endif %}>
+		<label for="{{ tab-group }}-{{ tab[0] }}" class="tab-link" onclick="setTab('{{ tab-group }}', '{{ tab[0] }}')">{{ tab[1] }}</label>
+		<div class="tab">{{ include.tabs[forloop.index0] | markdownify }}</div>
+	{% endfor %}
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,6 +26,10 @@ layout: compress
 
 	{% include footer.html %}
 
+	{% if content contains "tab-container" %}
+		<script src="/assets/js/tabs.js"></script>
+	{% endif %}
+
 	<script src="/assets/js/rescript.js"></script>
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW" crossorigin="anonymous"></script>
 </body>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -757,7 +757,6 @@ a.footnote::after {
 	margin-top: -3px;
 }
 
-
 @media only screen and (min-width: 576px) {
 	// Seems to be broken in RTL in bootstrap v5.0-beta1, so override here
 	html[dir=rtl] .dropdown-menu-sm-end {

--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -1,0 +1,55 @@
+const platforms = {
+	"Win32": "windows",
+	"MacIntel": "macos",
+	"MacPPC": "macos"
+};
+
+function setTab(tabGroup, tab) {
+	var url = window.location.href;
+	if(url.match(RegExp("[?&]" + tabGroup + "="))) { // Already has a tab param
+		url = url.replace(RegExp("([?&]" + tabGroup + "=)(.*?)(?=\\&|#|$)"), "$1" + tab)
+	} else if(url.match(/\?/)) { // Already has other search params
+		url = url.replace(/[?&].*?(?=#|$)/, "$&&" + tabGroup + "=" + tab);
+	} else { // No search params
+		url = url.replace(/(?=#|$)/, "?" + tabGroup + "=" + tab);
+	}
+
+	if(url != window.location.href) { // Don't update if not changed
+		history.pushState({}, "", encodeURI(url));
+		if(typeof updateLanguageAlert != "undefined") updateLanguageAlert(); // Language alert requires modern JS
+	}
+}
+
+function findTab(tabGroup, tabName) {
+	for(j = 0; j < tabGroup.children.length; j++) {
+		if(tabGroup.children[j].id.endsWith(tabName)) {
+			return tabGroup.children[j];
+		}
+	}
+}
+
+// Open the tabs for the current OS or the one in the URL
+const tabContainers = document.getElementsByClassName("tab-container");
+for(i = 0; i < tabContainers.length; i++) {
+	const tabGroup = tabContainers[i];
+	const tabGroupName = tabGroup.dataset["tabGroup"];
+
+	var tab = null;
+
+	// Try get tab from URL
+	const urlTab = decodeURI(window.location.href).match(RegExp("[?&]" + tabGroupName + "=(.*?)(?=\\&|#|$)"));
+	if(urlTab && urlTab.length > 1)
+		tab = findTab(tabGroup, urlTab[1]);
+
+	// Try get tab for OS
+	if(!tab)
+		tab = findTab(tabGroup, platforms[navigator.platform]);
+
+	// Fall back to "other" tab
+	if(!tab)
+		tab = findTab(tabGroup, "other");
+
+	// If a tab was found, open it
+	if(tab)
+		tab.click();
+}

--- a/pages/ds-quick-start-guide.md
+++ b/pages/ds-quick-start-guide.md
@@ -1,8 +1,15 @@
 ---
 title: A Quick Guide on DS Flashcarts
+tabs:
+  - unhacked: Unhacked 3DS/DSi
+    original-hacked: DS, DS Lite, hacked 3DS/DSi
+    non-recommended: Non-recommended
+  - dsi: DSi
+    3ds: 3DS
 ---
 
 Here are the best DS flashcarts currently available on the market. **If you're looking for a GBA flashcart, see the [GBA quick start guide](gba-quick-start-guide).** For other consoles, see the [quick start guide list](index.html).
+{:.alert .alert-info}
 
 ## READ FIRST
 
@@ -16,82 +23,170 @@ Here are the best DS flashcarts currently available on the market. **If you're l
 1. Do **not** buy a flashcart with a pre-loaded SD card. These SD cards are very cheap and will usually die on you within weeks. You will **not** be able to recover the files stored on them. Save yourself the hassle and buy a microSD card separately, being [cautious of SD card scams](https://www.youtube.com/watch?v=mSepkrHJv14).
 1. Older DS flashcarts may not work on the stock firmware of a DSi/3DS. Instead of being able to boot the cart, you will be presented with an error message instead. See the ['Alternative Options for DSi/3DS Users'](#alternative-options-for-dsi3ds-users) section for more information about why this happens and how to solve it!
 1. **Note that GBA emulation on these consoles is not perfect, refer to the [GBARunner2 Wiki](https://wiki.gbatemp.net/wiki/GBARunner2#DS_Compatibility_List) to check game compatibility.**
-1. **None of the carts listed here play 3DS games. Install CFW to run 3DS games, more details in the [3DS section](#3ds).**
+1. **None of the carts listed here play 3DS games. Install CFW to run 3DS games, more details in the [3DS section](?tab1=3ds#alternative-options-for-dsi3ds-users).**
 
-## Recommended carts for unhacked 3DS/DSi users:
+## Flashcarts
 
-<br>
+{% capture tab-unhacked %}
+## Ace3DS X
+![Ace3DS X](/assets/images/ds_carts/ace3dsx.png){:.float-start .me-3}
 
-| <span id="ace3ds-x">Ace3DS X</span> <br/>------------------------------ | Description <br/>--------------------------- |
-| ----------- | ----------- |
-| ![Ace3DS X](/assets/images/ds_carts/ace3dsx.png) |The Ace3DS X is a version of the Ace3DS+ (seen below) that also supports ntrboot with just a flick of a switch. <br><br> Ntrboot is a method that allows you to hack your 3DS easily, or fix a bricked 3DS family console. The Ace3DS X makes ntrboot easily accessible without any modification required, such as flashing the cartridge!<br><br> For general usage outside of hacking or unbricking, Ace3DS X clones are a good cheap option, however they have a few downsides. Due to iffy shell quality some report that it doesn't fit well into their consoles. It also runs an unofficial fork of Wood which lacks anti-piracy patches for some games. To play these games you will have to manually [AP patch their ROMs](https://gbatemp.net/download/retrogamefan-nds-rom-tool-v1-0_b1215.35735/), or use a cheat database and enable the Anti-Piracy bypass cheat before starting the game. Its biggest benefit is that it works on all DS family consoles up to latest 3DS consoles.|
-| Obtaining and Setup | This is recommended **for unhacked DSi and 3DS users** to buy, as well as people who are attempting to unbrick their console (or would like that peace of mind). Usually costs $5-10 USD. Searching "ace3ds" seems to correctly return results on AliExpress. Some links are provided here, but they may not be the cheapest options out there: {::nomarkdown}<ul><li>{:/}AliExpress: [https://www.aliexpress.com/item/1005005337644588.html](https://www.aliexpress.com/item/1005005337644588.html){::nomarkdown}</li><li>{:/} NDS-Card: [https://www.nds-card.com/ProShow.asp?ProID=575](https://www.nds-card.com/ProShow.asp?ProID=575){::nomarkdown}</li></ul>{:/} This cart uses the same kernel as the Ace3DS+, link provided below: {::nomarkdown}<ul><li>{:/} Kernel: [Ace3DS+ Wood R4 v1.62](https://flashcard-archive.ds-homebrew.com/Ace3DS+_R4iLS/Ace3DS+_R4iLS_Wood_R4_1.62.7z) {::nomarkdown}</li></ul>{:/} |
+The Ace3DS X is a version of the Ace3DS+ (seen below) that also supports ntrboot with just a flick of a switch.
 
-<br>
+Ntrboot is a method that allows you to hack your 3DS easily, or fix a bricked 3DS family console. The Ace3DS X makes ntrboot easily accessible without any modification required, such as flashing the cartridge!
 
-|  <span id="ace3ds+">Ace3DS+ Clones</span> <br/>--------------------------------- | Images and Description <br/>--------------------------------------- |
-| ----------- | ----------- |
-| Original cart (not sold): <br> ![Ace3DS+ Original](/assets/images/ds_carts/ace3ds+.png) | Multiple variations of this cart exist, and they're all clones of the cart shown on the left. Here are the most common ones: <br> ![r4isdhc.hk Ace3DS+ clone](/assets/images/ds_carts/r4isdhc_hk.png)![r4isdhc.com.cn Ace3DS+ clone](/assets/images/ds_carts/r4isdhc_com_cn.png) ![208 in 1 cart](/assets/images/ds_carts/208in1.png) ![Ace3DS+ Original](/assets/images/ds_carts/ace3ds-nolabel.png)|
-| Cart Info | These carts are clones of the Ace3DS+ flashcart, compatible with all DS, DSi, and 3DS consoles, even unhacked ones on the latest firmware. These Ace3DS+ clones **do not** work with ntrboot - see the [Ace3DS X](#ace3ds-x) instead if this is a feature that you may need. <br><br> Important distinction: past listings of unlabeled Ace3DS+ clones exist, but we can no longer advise the purchase of these carts as they have started mixing in older versions of the Ace3DS+ which do not work on the latest firmware. More confusion arises from the fact that there are also timebomb clones that have very similar looking PCBs to the Ace3DS+ unlabeled carts. Please purchase the other labeled variants instead, specifically the two shown above. <br><br> Ace3DS+ clones are a good cheap option, however they have a few downsides. Due to iffy shell quality some report that it doesn't fit well into their consoles. It also runs an older version of Wood which lacks some anti-piracy patches, so to play certain games you will have to manually [patch their ROMs](https://gbatemp.net/download/retrogamefan-nds-rom-tool-v1-0_b1215.35735/), or use a cheat database and enable the Anti-Piracy bypass cheat before starting the game. <br><br> |
-| Obtaining and Setup | Searching "r4 wood" on AliExpress or "r4" on eBay usually returns this cart. A link is provided here, but this may not be the cheapest option as it's one of many listings: [https://www.aliexpress.com/item/1005003830660409.html](https://www.aliexpress.com/item/1005003830660409.html) <br><br> These carts are sold under a variety of brandings. The 2020 and later carts labelled as r4isdhc**.hk** and r4isdhc**.com.cn**, and "208-in-1" carts are  Ace3DS+ clones. Aside from the distinction note above, all of these carts perform identically regardless of branding. <br><br> Note that there exist similar carts looking carts that are **not** Ace3DS+ clones, but rather [timebomb clones](#timebomb_clone). These include carts labelled as r4isdhc**.com** and some unlabelled red PCB carts. The notable physical differences are: {::nomarkdown}<ul><li> Ace3DS+ clones have either one or five holes in the PCB near the pins, the similar timebomb clones have two. (see above images) </li><ul><li> NOTE: It has been reported that the 5 hole PCB variant do not work on unmodded DSi/3DS consoles. This is mostly prominent on unlabeled Ace3DS+ clones, so do not purchase unlabeled carts.</li></ul><li> Ace3DS+ clones have smaller but deeper indents on the sides </li><li> Timebomb clones typically have an oval shaped indent in the plastic on the back, while Ace3DS+ clones don't.</li><li>Ace3DS+ clones always have red PCBs, timebomb clones often have yellow PCBs but are occasionally red as well. </li></ul>{:/} Kernel: [Ace3DS+ Wood R4 v1.62](https://flashcard-archive.ds-homebrew.com/Ace3DS+_R4iLS/Ace3DS+_R4iLS_Wood_R4_1.62.7z) |
-
-<br>
-
-| <span id="timebomb_clone">DSTTi Timebomb Clones</span> <br/>------------------------------ | Images and Description <br/>--------------------------------------- |
-| ----------- | ----------- |
-| ![r4i-sdhc.com 3DS RTS](/assets/images/ds_carts/r4i-sdhc_3ds_rts.png) | ![r4isdhc.com gold cart](/assets/images/ds_carts/r4isdhc_com_front.png) ![r4isdhc.com dual-core cart](/assets/images/ds_carts/r4isdhc_com_back.png) ![Unlabelled timebomb clone](/assets/images/ds_carts/timebomb_back.png)|
-| Cart Info | These common carts are clones of the DSTTi, but with a timebomb in their official kernel. The timebomb is purely software, so switching to an alternative kernel will remove it. These carts are compatible with all DS, DSi, and 3DS consoles - even on the latest firmware - so they make a decent choice for unhacked DSi/3DS users, but the above [Ace3DS+ clones](#ace3ds+) are recommended instead if possible. <br><br> Most of these carts sold today are labelled as r4isdhc**.com** or r4i-sdhc.**com**, but others do exist. The timebomb causes the cart to stop loading into the menu after a certain date, but can be fixed by either switching to the YSMenu kernel or the de-timebombed stock kernel. Ace3DS+ clones are recommended instead due to the Wood kernel having higher compatibility with certain features such as Wii connectivity in DS games. <br><br> One notable advantage of these carts over DSOne or Ace3DS+ clones is that they support ntrboot for installing CFW on a 3DS. If you are looking for a cart with ntrboot support, then these carts are a decent choice. However, the Ace3DS X above is preferable for that purpose, since it has ntrboot preflashed and uses a better kernel when in DS mode. |
-| Obtaining and Setup | This is only recommended **if you cannot buy an Ace3DS X or Ace3DS+ clone**. Usually costs $10-15 USD. Searching "r4 gold pro" on AliExpress or eBay usually returns this cart. A link is provided here, but this may not be the cheapest option as it's one of many listings: [https://www.aliexpress.com/item/1005004530389743.html](https://www.aliexpress.com/item/1005004530389743.html) {::nomarkdown}<ul><li>{:/} Kernel: [YSMenu](https://gbatemp.net/threads/retrogamefan-updates-releases.267243/) {::nomarkdown}</li><li>{:/} Alternate Kernel: [De-Timebombed 1.85b r4i-sdhc kernel](https://github.com/DS-Homebrew/flashcard-archive/blob/archive/files/YSMenu/DEMON_common/r4i-sdhc.com_DEMON_1.85b-no-timebomb.zip){::nomarkdown}</li></ul>{:/} |
-
-## Recommended carts for NDS, DS Lite, and hacked 3DS/DSi users:
-
-<br>
-
-|  <span id="dsone">DSOne SDHC</span> <br/>------------------------------ | Description <br/>--------------------------- |
-| ----------- | ----------- |
-| ![DSOne SDHC](/assets/images/ds_carts/dsone_sdhc.jpeg) |A clone of the SuperCard DSOne SDHC, these carts have more or less perfect compatibility with retail games, plus features like RTS, slowdown, and an in-game menu not commonly found in other carts. This cart only works on DS Phat/Lite and hacked DSi/3DS - **it will not work on stock DSi/3DS**. <br><br> While it's an excellent choice, it has a relatively high defective cart rate, so buying two or three is recommended if you'd like to ensure you get a fully functional cart. Defective carts will still work with YSMenu, but will not be able to take advantage of the extra features provided by its usual Evolution OS kernel. <br><br> Note that these carts can also be found with a [DSONEi label](https://i.imgur.com/JsZZC8N.png), but they are not DSONEi carts in reality. They are DSONE SDHC carts with a DSONEi label. |
-| Obtaining and Setup | This is the most recommended cart **for use on DS Lite/Phat and hacked systems**. Costs $5-10 USD. Searching "dsone" on AliExpress or eBay usually returns this cart. <br><br> A link is provided here, but this may not be the cheapest option as it's one of the many listings: [https://www.aliexpress.com/item/1005002378653693.html](https://www.aliexpress.com/item/1005002378653693.html) {::nomarkdown}<ul><li>{:/} Kernel: [Evolution OS](https://flashcard-archive.ds-homebrew.com/SuperCard/DSONE_SDHC_DSONEi/SuperCard_DSONE_SDHC_EOS_sp6_20121206.zip) {::nomarkdown}</li><li>{:/} Alternate kernel: [YSMenu](https://gbatemp.net/threads/retrogamefan-updates-releases.267243/) (Only use if Evolution OS gives a PSRAM error) {::nomarkdown}</li></ul>{:/} A guide to using and setting up the DSOne SDHC is here: [https://github.com/Sanrax/DSOneManual](https://github.com/Sanrax/DSOneManual) |
-
-<br>
-
-|  <span id="r4ds_pro">R4DS Pro</span> <br/>------------------------------ | Description <br/>--------------------------- |
-| ----------- | ----------- |
-| ![R4DS Pro](/assets/images/ds_carts/r4ds_pro.png) | While on the surface this may look like an original R4 clone - and is often described as an original R4 - this is actually an **r4dspro.com** clone instead. It is based on the R4 Ultra which is a derivative of the Acekard 2i. It does not pass AKAIO's clone checks, however, it can run BL2CK OS like most other Acekard2i based carts. **Note that this cart will not work on a stock DSi/3DS**.<br><br> Ideally, the <a href="#dsone">DSOne SDHC</a> is a better choice for most people using a DS Lite. This cart isn't that much better than the <a href="#ace3ds+">Ace3ds+ clones</a> mentioned before. Unless it's your only option, we would suggest picking up a different cart.|
-| Obtaining and Setup | This cart is only recommended **if you cannot buy any of the other carts mentioned here**. Costs $3-8 USD. Searching "R4 DS" on AliExpress or eBay may return this cart. <br><br> Links are provided here, but they may not be the cheapest options: {::nomarkdown}<ul><li>{:/}AliExpress: [Link 1](https://www.aliexpress.com/item/3256804832983831.html), [Link 2](https://www.aliexpress.com/item/3256804870490222.html).{::nomarkdown}</li><li>{:/} eBay (UK): [https://www.ebay.co.uk/itm/404351104392](https://www.ebay.co.uk/itm/404351104392).{::nomarkdown}</li></ul>{:/} BL2CK is the recommended kernel for this cart alongside [TWiLight Menu++](https://wiki.ds-homebrew.com/twilightmenu/installing-flashcard). A link to the stock kernel is provided as another option: {::nomarkdown}<ul><li>{:/} Kernel: [BL2CK](https://flashcard-archive.ds-homebrew.com/BL2CK/BL2CK_1.30.4.zip) {::nomarkdown}</li><li>{:/} Alternate kernel: [Stock kernel](https://flashcard-archive.ds-homebrew.com/r4dspro.com/r4dspro.com_Kernel_1.50.7z) {::nomarkdown}</li></ul>{:/}|
+For general usage outside of hacking or unbricking, Ace3DS X clones are a good cheap option, however they have a few downsides. Due to iffy shell quality some report that it doesn't fit well into their consoles. It also runs an unofficial fork of Wood which lacks anti-piracy patches for some games. To play these games you will have to manually [AP patch their ROMs](https://gbatemp.net/download/retrogamefan-nds-rom-tool-v1-0_b1215.35735/), or use a cheat database and enable the Anti-Piracy bypass cheat before starting the game. Its biggest benefit is that it works on all DS family consoles up to latest 3DS consoles.
 
 
-## Non-recommended carts
+### Obtaining and Setup
+This is recommended **for unhacked DSi and 3DS users** to buy, as well as people who are attempting to unbrick their console (or would like that peace of mind). Usually costs $5-10 USD. Searching "ace3ds" seems to correctly return results on AliExpress. Some links are provided here, but they may not be the cheapest options out there:
+- AliExpress: <https://www.aliexpress.com/item/1005005337644588.html>
+- NDS-Card: <https://www.nds-card.com/ProShow.asp?ProID=575>
 
-### These are carts that you may encounter but are generally NOT recommended:
+This cart uses the same kernel as the Ace3DS+, link provided below
+- Kernel: [Ace3DS+ Wood R4 v1.62](https://flashcard-archive.ds-homebrew.com/Ace3DS+_R4iLS/Ace3DS+_R4iLS_Wood_R4_1.62.7z)
 
-|  R4 DS <br/>------------------------------ | Description <br/>--------------------------- |
-| ----------- | ----------- |
-| ![R4 DS](/assets/images/ds_carts/r4ds.png) | Identical (1:1) clones of the original R4 cart are available on AliExpress, but they are not recommended due to only supporting 2 GB or smaller microSD cards. They also do not work in unhacked DSi and 3DS systems. Even on hacked 3DS and DSi systems, they can only be launched via TWiLight Menu++ or homebrew like [NTR_Launcher](https://github.com/ApacheThunder/NTR_Launcher), due to not showing up in the console's home menu when inserted. <br><br> Despite all these flaws listed above, they do however use a great kernel - Official Wood R4 1.62, which has near-perfect game compatibility. <br><br> These clones on AliExpress can be identified by their green PCB with the text "ROHS Card 7a", inside of a grey, unlabeled shell. It usually costs around $5. Even though they are relatively cheap, your money would likely be better invested in one of the recommended carts above instead. |
+## Ace3DS+ Clones
+![Ace3DS+ Original](/assets/images/ds_carts/ace3ds+.png){:.float-start .me-3}
 
-<br>
+These carts are clones of the Ace3DS+ flashcart, compatible with all DS, DSi, and 3DS consoles, even unhacked ones on the latest firmware. These Ace3DS+ clones **do not** work with ntrboot - see the [Ace3DS X](#ace3ds-x) instead if this is a feature that you may need.
 
-|  R4i Gold 3DS Plus <br/>------------------------------ | Description <br/>--------------------------- |
-| ----------- | ----------- |
-| ![R4i Gold 3DS Plus](/assets/images/ds_carts/r4i_gold_3ds_plus.png) | This cart halted production at the start of 2020. They were formerly highly recommended carts with a highly compatible and feature-rich kernel (Wood R4 1.64), but their last batch was faulty and cannot play NDS ROMs - thus, they are no longer recommended. Do not follow any old advice saying to buy them. <br><br>This refers specifically to the *R4i Gold 3DS Plus* from **r4ids.cn**, they should not be confused with carts from any other website. |
+Important distinction: past listings of unlabeled Ace3DS+ clones exist, but we can no longer advise the purchase of these carts as they have started mixing in older versions of the Ace3DS+ which do not work on the latest firmware. More confusion arises from the fact that there are also timebomb clones that have very similar looking PCBs to the Ace3DS+ unlabeled carts. Please purchase the other labeled variants instead, specifically the two shown above.
+
+Ace3DS+ clones are a good cheap option, however they have a few downsides. Due to iffy shell quality some report that it doesn't fit well into their consoles. It also runs an older version of Wood which lacks some anti-piracy patches, so to play certain games you will have to manually [patch their ROMs](https://gbatemp.net/download/retrogamefan-nds-rom-tool-v1-0_b1215.35735/), or use a cheat database and enable the Anti-Piracy bypass cheat before starting the game.
+
+### Variants
+Multiple variations of this cart exist, and they're all clones of the cart shown above. Here are the most common ones:
+
+![r4isdhc.hk Ace3DS+ clone](/assets/images/ds_carts/r4isdhc_hk.png)
+![r4isdhc.com.cn Ace3DS+ clone](/assets/images/ds_carts/r4isdhc_com_cn.png)
+![208 in 1 cart](/assets/images/ds_carts/208in1.png)
+![Ace3DS+ Original](/assets/images/ds_carts/ace3ds-nolabel.png)
+
+### Obtaining and Setup
+Searching "r4 wood" on AliExpress or "r4" on eBay usually returns this cart. A link is provided here, but this may not be the cheapest option as it's one of many listings: <https://www.aliexpress.com/item/1005003830660409.html>
+
+These carts are sold under a variety of brandings. The 2020 and later carts labelled as r4isdhc**.hk** and r4isdhc**.com.cn**, and "208-in-1" carts are Ace3DS+ clones. Aside from the distinction note above, all of these carts perform identically regardless of branding.
+
+Note that there exist similar carts looking carts that are **not** Ace3DS+ clones, but rather [timebomb clones](#timebomb_clone). These include carts labelled as r4isdhc**.com** and some unlabelled red PCB carts. The notable physical differences are:
+- Ace3DS+ clones have either one or five holes in the PCB near the pins, the similar timebomb clones have two. (see above images)
+   - NOTE: It has been reported that the 5 hole PCB variant do not work on unmodded DSi/3DS consoles. This is mostly prominent on unlabeled Ace3DS+ clones, so do not purchase unlabeled carts.
+- Ace3DS+ clones have smaller but deeper indents on the sides
+- Timebomb clones typically have an oval shaped indent in the plastic on the back, while Ace3DS+ clones don't.
+- Ace3DS+ clones always have red PCBs, timebomb clones often have yellow PCBs but are occasionally red as well.
+
+Kernel: [Ace3DS+ Wood R4 v1.62](https://flashcard-archive.ds-homebrew.com/Ace3DS+_R4iLS/Ace3DS+_R4iLS_Wood_R4_1.62.7z)
+
+## DSTTi Timebomb Clones
+![r4i-sdhc.com 3DS RTS](/assets/images/ds_carts/r4i-sdhc_3ds_rts.png){:.float-start .me-3}
+
+These common carts are clones of the DSTTi, but with a timebomb in their official kernel. The timebomb is purely software, so switching to an alternative kernel will remove it. These carts are compatible with all DS, DSi, and 3DS consoles - even on the latest firmware - so they make a decent choice for unhacked DSi/3DS users, but the above [Ace3DS+ clones](#ace3ds-clones) are recommended instead if possible.
+
+Most of these carts sold today are labelled as r4isdhc.**com** or r4i-sdhc.**com**, but others do exist. The timebomb causes the cart to stop loading into the menu after a certain date, but can be fixed by either switching to the YSMenu kernel or the de-timebombed stock kernel. Ace3DS+ clones are recommended instead due to the Wood kernel having higher compatibility with certain features such as Wii connectivity in DS games.
+
+One notable advantage of these carts over [DSOne](?tab=original-hacked#dsone-sdhc) or Ace3DS+ clones is that they support ntrboot for installing CFW on a 3DS. If you are looking for a cart with ntrboot support, then these carts are a decent choice. However, the [Ace3DS X](#ace3ds-x) above is preferable for that purpose, since it has ntrboot preflashed and uses a better kernel when in DS mode.
+
+### Variants
+![r4isdhc.com gold cart](/assets/images/ds_carts/r4isdhc_com_front.png)
+![r4isdhc.com dual-core cart](/assets/images/ds_carts/r4isdhc_com_back.png)
+![Unlabelled timebomb clone](/assets/images/ds_carts/timebomb_back.png)
+
+### Obtaining and Setup
+This is only recommended **if you cannot buy an Ace3DS X or Ace3DS+ clone**. Usually costs $10-15 USD. Searching "r4 gold pro" on AliExpress or eBay usually returns this cart. A link is provided here, but this may not be the cheapest option as it's one of many listings: <https://www.aliexpress.com/item/1005004530389743.html>
+
+- Kernel: [YSMenu](https://gbatemp.net/threads/retrogamefan-updates-releases.267243/)
+- Alternate Kernel: [De-Timebombed 1.85b r4i-sdhc kernel](https://github.com/DS-Homebrew/flashcard-archive/blob/archive/files/YSMenu/DEMON_common/r4i-sdhc.com_DEMON_1.85b-no-timebomb.zip)
+{% endcapture %}
+{% assign tab-unhacked = tab-unhacked | split: "////////" %}
+
+{% capture tab-original-hacked %}
+## DSOne SDHC
+![DSOne SDHC](/assets/images/ds_carts/dsone_sdhc.jpeg){:.float-start .me-3}
+
+A clone of the SuperCard DSOne SDHC, these carts have more or less perfect compatibility with retail games, plus features like RTS, slowdown, and an in-game menu not commonly found in other carts. This cart only works on DS Phat/Lite and hacked DSi/3DS - **it will not work on stock DSi/3DS**.
+
+While it's an excellent choice, it has a relatively high defective cart rate, so buying two or three is recommended if you'd like to ensure you get a fully functional cart. Defective carts will still work with YSMenu, but will not be able to take advantage of the extra features provided by its usual Evolution OS kernel.
+
+Note that these carts can also be found with a [DSONEi label](https://i.imgur.com/JsZZC8N.png), but they are not DSONEi carts in reality. They are DSONE SDHC carts with a DSONEi label.
+
+### Obtaining and Setup
+This is the most recommended cart **for use on DS Lite/Phat and hacked systems**. Costs $5-10 USD. Searching "dsone" on AliExpress or eBay usually returns this cart.
+
+A link is provided here, but this may not be the cheapest option as it's one of the many listings: <https://www.aliexpress.com/item/1005002378653693.html>
+
+- Kernel: [Evolution OS](https://flashcard-archive.ds-homebrew.com/SuperCard/DSONE_SDHC_DSONEi/SuperCard_DSONE_SDHC_EOS_sp6_20121206.zip)
+- Alternate kernel: [YSMenu](https://gbatemp.net/threads/retrogamefan-updates-releases.267243/) (Only use if Evolution OS gives a PSRAM error)
+
+A guide to using and setting up the DSOne SDHC is here: <https://github.com/Sanrax/DSOneManual>
+
+### R4DS Pro
+![R4DS Pro](/assets/images/ds_carts/r4ds_pro.png){:.float-start .me-3}
+
+While on the surface this may look like an original R4 clone - and is often described as an original R4 - this is actually an **r4dspro.com** clone instead. It is based on the R4 Ultra which is a derivative of the Acekard 2i. It does not pass AKAIO's clone checks, however, it can run BL2CK OS like most other Acekard2i based carts. **Note that this cart will not work on a stock DSi/3DS**.
+
+Ideally, the [DSOne SDHC](#dsone-sdhc) is a better choice for most people using a DS Lite. This cart isn't that much better than the [Ace3ds+ clones](?tab=unhacked#ace3ds-clones) mentioned before. Unless it's your only option, we would suggest picking up a different cart.
+
+### Obtaining and Setup
+This cart is only recommended **if you cannot buy any of the other carts mentioned here**. Costs $3-8 USD. Searching "R4 DS" on AliExpress or eBay may return this cart.
+
+Links are provided here, but they may not be the cheapest options:
+- AliExpress: [Listing 1](https://www.aliexpress.com/item/3256804832983831.html), [Listing 2](https://www.aliexpress.com/item/3256804870490222.html)
+- eBay (UK): <https://www.ebay.co.uk/itm/404351104392>
+
+BL2CK is the recommended kernel for this cart alongside [TWiLight Menu++](https://wiki.ds-homebrew.com/twilightmenu/installing-flashcard). The stock kernel is also an option:
+- Kernel: [BL2CK](https://flashcard-archive.ds-homebrew.com/BL2CK/BL2CK_1.30.4.zip)
+- Alternate kernel: [Stock kernel](https://flashcard-archive.ds-homebrew.com/r4dspro.com/r4dspro.com_Kernel_1.50.7z)
+{% endcapture %}
+{% assign tab-original-hacked = tab-original-hacked | split: "////////" %}
+
+{% capture tab-non-recommended %}
+These are carts that you may encounter but are generally NOT recommended.
+{:.alert .alert-warning}
+
+## R4 DS
+![R4 DS](/assets/images/ds_carts/r4ds.png){:.float-start .me-3}
+
+Identical (1:1) clones of the original R4 cart are available on AliExpress, but they are not recommended due to only supporting 2 GB or smaller microSD cards. They also do not work in unhacked DSi and 3DS systems. Even on hacked 3DS and DSi systems, they can only be launched via TWiLight Menu++ or homebrew like [NTR_Launcher](https://github.com/ApacheThunder/NTR_Launcher), due to not showing up in the console's home menu when inserted.
+
+Despite all these flaws listed above, they do however use a great kernel - Official Wood R4 1.62, which has near-perfect game compatibility.
+
+These clones on AliExpress can be identified by their green PCB with the text "ROHS Card 7a", inside of a grey, unlabeled shell. It usually costs around $5. Even though they are relatively cheap, your money would likely be better invested in one of the recommended carts above instead.
+
+## R4i Gold 3DS Plus
+![R4i Gold 3DS Plus](/assets/images/ds_carts/r4i_gold_3ds_plus.png){:.float-start .me-3}
+
+This cart halted production at the start of 2020. They were formerly highly recommended carts with a highly compatible and feature-rich kernel (Wood R4 1.64), but their last batch was faulty and cannot play NDS ROMs - thus, they are no longer recommended. Do not follow any old advice saying to buy them.
+
+This refers specifically to the *R4i Gold 3DS Plus* from **r4ids.cn**, they should not be confused with carts from any other website.
+{% endcapture %}
+{% assign tab-non-recommended = tab-non-recommended | split: "////////" %}
+
+{% assign tabs = tab-unhacked | concat: tab-original-hacked | concat: tab-non-recommended %}
+{% include tabs.html index=0 tabs=tabs %}
 
 ## Alternative Options for DSi/3DS Users
 
-### DSi
-
-On the DSi/DSi XL consoles, Nintendo introduced a whitelist and RSA signatures in an attempt to prevent flashcarts from functioning, so you need to be careful which flashcart you buy to use it on a DSi. Because of this the [Ace3DS+ clones](#ace3ds+) are recommended if you choose to buy a flashcart for use on a DSi, as they are supported all the way up to the latest firmware version.
+{% capture tab-dsi %}
+On the DSi/DSi XL consoles, Nintendo introduced a whitelist and RSA signatures in an attempt to prevent flashcarts from functioning, so you need to be careful which flashcart you buy to use it on a DSi. Because of this the [Ace3DS+ clones](#ace3ds-clones) are recommended if you choose to buy a flashcart for use on a DSi, as they are supported all the way up to the latest firmware version.
 
 If you boot an unsupported flashcart on a stock DSi, it will show black screens with white text that says "[An error has occurred](https://i.imgur.com/gE47UKA.png)". This can be bypassed by installing CFW on your DSi. Specifically, Unlaunch is required - with it, you will be able to load the flashcart from the DSi Menu if it was installed with launcher patches enabled or from Unlaunch itself, TWiLight Menu++, or hiyaCFW regardless whether or not Unlaunch's launcher patches are enabled.
 
 On a hacked DSi, there is also the option to play DS games using nds-bootstrap (via [TWiLight Menu++](https://wiki.ds-homebrew.com/twilightmenu/)). This allows games to be loaded from the DSi's SD card without needing to purchase anything besides an SD card if you don't already have one. However, nds-bootstrap's [compatibility](https://docs.google.com/spreadsheets/d/1LRTkXOUXraTMjg1eedz_f7b5jiuyMv2x6e_jY_nyHSc/htmlview) isn't quite as good as that of flashcarts so buying a flashcart can still be worthwhile if you run into incompatible games. It is generally recommended to try the CFW route first, and only buy a flashcart if you want to play a game that isn't compatible, or want the portability of a flashcart - being able to share the same save files by simply moving the flashcart over to another DS console.
 
 See [dsi.cfw.guide](https://dsi.cfw.guide) for a guide on how to install CFW on your DSi.
+{% endcapture %}
+{% assign tab-dsi = tab-dsi | split: "////////" %}
 
-### 3DS
-
+{% capture tab-3ds %}
 On the 3DS family of consoles (including the 2DS and XL variants) there is a distinction between flashcarts that play 3DS games and flashcarts that play DS games. Flashcarts that play 3DS games are rendered mostly useless by the existence of CFW, which has *better* compatibility and is completely free, while 3DS flashcarts are very expensive. CFW also has other benefits over 3DS flashcarts such as the ability to run homebrew and emulators.
 
-Flashcarts for playing DS games on the other hand can still be useful, and everything in the [DSi](#dsi) section above applies to DS mode flashcarts on the 3DS as well. That is, [TWiLight Menu++](https://wiki.ds-homebrew.com/twilightmenu/installing-3ds.html) being a good option, but flashcarts for DS games having slightly higher compatibility. The [Ace3DS X](#ace3ds-x) carts are the recommended DS flashcart for 3DS users as they support the latest 3DS firmware without needing CFW, and provide ntrboot in the case you may need it. Any DS flashcart can be run with CFW, either from the 3DS HOME Menu or TWiLight Menu++. Thus for CFW users, [DSOne SDHC](#dsone) is also a great option.
+Flashcarts for playing DS games on the other hand can still be useful, and everything in the [DSi](#dsi) section above applies to DS mode flashcarts on the 3DS as well. That is, [TWiLight Menu++](https://wiki.ds-homebrew.com/twilightmenu/installing-3ds.html) being a good option, but flashcarts for DS games having slightly higher compatibility. The [Ace3DS X](#ace3ds-x) carts are the recommended DS flashcart for 3DS users as they support the latest 3DS firmware without needing CFW, and provide ntrboot in the case you may need it. Any DS flashcart can be run with CFW, either from the 3DS HOME Menu or TWiLight Menu++. Thus for CFW users, [DSOne SDHC](#dsone-sdhc) is also a great option.
 
 See [3ds.hacks.guide](https://3ds.hacks.guide) for how to install CFW on your 3DS.
+{% endcapture %}
+{% assign tab-3ds = tab-3ds | split: "////////" %}
+
+{% assign tabs = tab-dsi | concat: tab-3ds %}
+{% include tabs.html index=1 tabs=tabs %}
 
 {% include_relative include/disclaimer.md %}


### PR DESCRIPTION
Switches the DS guide to use tabs, based on the DS-Homebrew wiki, live demo: https://fwiki.ピケ.コム/ds-quick-start-guide

imo using tables doesn't really make much sense for this, it looks bad on mobile, is terrible for accessibility, and doesn't work well with Markdown.

This may work better with nested tabs, a la:
(**Unhacked 3DS/DSi**) (DS, DS Lite, Hacked 3DS) (Non-recommended)
> (**Ace3DS X**) (Ace3DS+ Clones) (Timebomb Clones)
> > blah blah blah

The tab code is compatible with that, I just wasn't sure which I preferred so I left it as the simpler option for now.